### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Land
+version: 3.0
+organization: Land
+product: Tjenester
+repo_types: [Training]
+platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,1 @@
+{"timestamp":"2024-05-02T11:19:36.728+00:00","status":500,"error":"Internal Server Error","path":"/api/backstage/catalogInfo/example-clients"}


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Land`
- `product: Tjenester`
- `repo_types: [Training]`
- `platforms: []`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.