### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,1 +1,1 @@
-{"timestamp":"2024-05-02T11:19:36.728+00:00","status":500,"error":"Internal Server Error","path":"/api/backstage/catalogInfo/example-clients"}
+{"timestamp":"2024-05-21T14:12:36.560+00:00","status":500,"error":"Internal Server Error","path":"/api/backstage/catalogInfo/example-clients"}


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.